### PR TITLE
fix rendered within the UI as comma separation of multiple roles for …

### DIFF
--- a/src/pages/studyDetail/views/overview/StudyPersonnel.js
+++ b/src/pages/studyDetail/views/overview/StudyPersonnel.js
@@ -11,8 +11,13 @@ import { configColumn } from './tableConfig/Column';
 
 const StudyPersonnel = (props) => {
   const config = studyPersonnelTableConfig;
-  const { data } = props;
+  let { data } = props;
 
+    // Modify data to replace "|" with "," in person_role if it's not null
+  data = data.map(item => ({
+    ...item,
+    person_role: item.person_role ? item.person_role.replace(/\|/g, ', ') : item.person_role
+  }));
   /**
     * initialize state for useReducer
     * @param {*} initailState


### PR DESCRIPTION
Updated requirements to cover the pipe separation of multiple roles specified within the study personnel data loading file being rendered within the UI as comma separation of multiple roles for any given member of the study personnel team.

[POPSCI-30](https://tracker.nci.nih.gov/browse/POPSCI-30) 