### PR TITLE
Rename radio label to "By Uberon Disease Site"

### DIFF
--- a/src/pages/studyDetail/views/cancerTypes/index.js
+++ b/src/pages/studyDetail/views/cancerTypes/index.js
@@ -228,7 +228,7 @@ const CancerTypes = ({ classes, data }) => {
                     <FormControlLabel
                       value="PrimaryDiseaseSite"
                       control={<CustomRadio />}
-                      label="by Primary Disease Site"
+                      label="by Uberon Primary Disease Site" 
                       classes={{
                         root:  classes.radioButtonSpacing,
                         label: classes.CancerTypeLabel,


### PR DESCRIPTION
This pull request makes a minor update to the `CancerTypes` component in the `src/pages/studyDetail/views/cancerTypes/index.js` file. The label for the radio button has been updated for clarity.

Related ticket: POPSCI-293