### PR TITLE
POPSCI-262: Integrate data_file_access_control

### DIFF
--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -366,7 +366,7 @@ export const studyDataFileTableConfig = {
       role: cellTypes.DISPLAY,
     },
     {
-      dataField: 'data_file_size',
+      dataField: 'data_volume',
       header: 'Size',
       display: true,
       tooltipText: 'sort',

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -115,23 +115,21 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
         publication_record_id
       }
 
-      data_file {
-        data_file_uuid
-        association
-        data_file_name
-        data_file_type
-        data_file_description
-        data_file_format
-        data_file_size
-        data_file_location
-        data_file_signed_url
-      }
-
       associated_links {
         associated_link_name
         associated_link_record_id
         associated_link_url
       }
+    }
+
+    studyFiles( study_short_name: $study_short_name) {
+      data_file_uuid
+      data_file_name
+      data_file_type
+      data_file_description
+      data_file_format
+      data_volume # data_file_size
+      data_file_access_control
     }
 
     tabStudy(study_short_name: $study_short_name) {

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -42,7 +42,7 @@ const StudyDetailView = ({ classes, data, isLoading=false, isError=false, studyS
   const studyGeneral = {...data?.studyGeneral?.at(0), ...data?.tabStudy?.at(0), ...data?.globalStatsBar?.at(0)};
   const studyDemographics = data?.studyDemographics?.at(0);
   const primarySiteMorphology = data?.primarySiteMorphology?.at(0);
-
+  const studyFiles = data?.studyFiles;
 
   const statsbarData = {
     ...data.searchStudies,
@@ -61,7 +61,7 @@ const StudyDetailView = ({ classes, data, isLoading=false, isError=false, studyS
     { index: 3, label: 'Data Collected' ,content: <DataCollection data={data?.dataCollectionPage[0].data_collection || {}} /> },
     { index: 4, label: 'Countries and States',content: <Country data={studyGeneral || {}} /> },
     { index: 5, label: 'Publications', content: <Publications data={studyGeneral || {}} /> },
-    { index: 6, label: 'Study Files', content: <StudyFiles data={studyGeneral || {}} studyShortName={studyShortName} />},
+    { index: 6, label: 'Study Files', content: <StudyFiles data={studyFiles || {}} studyShortName={studyShortName} />},
   ];
 
   if (isLoading) return <CircularProgress />;

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -61,7 +61,7 @@ const StudyDetailView = ({ classes, data, isLoading=false, isError=false, studyS
     { index: 3, label: 'Data Collected' ,content: <DataCollection data={data?.dataCollectionPage[0].data_collection || {}} /> },
     { index: 4, label: 'Countries and States',content: <Country data={studyGeneral || {}} /> },
     { index: 5, label: 'Publications', content: <Publications data={studyGeneral || {}} /> },
-    { index: 6, label: 'Study Files', content: <StudyFiles data={studyFiles || {}} studyShortName={studyShortName} />},
+    { index: 6, label: 'Study Files', content: <StudyFiles data={studyFiles || []} studyShortName={studyShortName} />},
   ];
 
   if (isLoading) return <CircularProgress />;

--- a/src/pages/studyDetail/views/studyFiles/index.js
+++ b/src/pages/studyDetail/views/studyFiles/index.js
@@ -1,35 +1,37 @@
 import React from 'react';
-import {
-  withStyles,
-} from '@material-ui/core';
+import { withStyles, Typography } from '@material-ui/core';
 import OverviewThemeProvider from './ThemeConfig';
-import StudyPersonnel from './StudyFileTable';
+import StudyFileTable from './StudyFileTable';
 import styles from './style';
 
-const StudyFiles = ({ classes, data, studyShortName }) => {
-  const accessTypes = ["Open Access", "Controlled Access"];
-  
-  const { data_file = [] } = data;
-  const data_file_with_access = data_file.map(item => ({
-    ...item,
-    data_file_access_control: item.data_file_access_control || accessTypes[Math.floor(Math.random() * accessTypes.length)] || "Unknown Access"
-  }));
-  
+/**
+ * Component for displaying study files in a table format
+ * @param {Object} props - Component props
+ * @param {Object} props.classes - Material-UI classes
+ * @param {Array} props.data - Array of file data
+ * @param {string} props.studyShortName - Short name of the study
+ */
+const StudyFiles = ({ classes, data = [], studyShortName }) => {
+  const hasFiles = Array.isArray(data) && data.length > 0;
+
+  const renderNoFilesMessage = () => (
+    <div className={classes.noStudyRecords}>
+      <Typography className={classes.noData} variant="body1" align="center">
+        This Study currently has no Files associated with it
+      </Typography>
+    </div>
+  );
+
+  const renderFilesTable = () => (
+    <div className={classes.studyPersonnelTable}>
+      <StudyFileTable data={data} studyShortName={studyShortName} />
+    </div>
+  );
+
   return (
     <OverviewThemeProvider>
-      {/* Study Personnel Section */}
       <div className={classes.studyFileContainer}>
-        {data_file_with_access.length > 0 ? (
-          <div className={classes.studyPersonnelTable}>
-            <StudyPersonnel data={data_file_with_access} studyShortName={studyShortName} />
-          </div>
-        ): (
-          <div className={classes.noStudyRecords}>
-            <p className={classes.noData}>
-              This Study currently has no Files associated with it
-            </p>
-          </div> 
-        )}
+        {hasFiles ? renderFilesTable() : renderNoFilesMessage()}
       </div>
     </OverviewThemeProvider>
   );


### PR DESCRIPTION
This pull request refactors how study file data is fetched and displayed in the study detail view. The main change is the replacement of the legacy `data_file` field with a new `studyFiles` query and removing mock data for `data_file_access_control`