### PR TITLE
POPSCI-307: Refactor dashboard widgets for participant and cancer type counts

### DIFF
--- a/src/bento/dashTemplate.js
+++ b/src/bento/dashTemplate.js
@@ -282,7 +282,7 @@ export const widgetConfig = [
     type: 'donut',
     title: 'Studies: Participant Count',
     sliceTitle: "Participants",
-    dataName: 'globalStatsBar',
+    dataName: 'participantCountWidget',
   },
   {
     type: 'donut',
@@ -294,6 +294,6 @@ export const widgetConfig = [
     type: 'donut',
     title: 'Studies: Cancer Type Count',
     sliceTitle: "Cancer Types",
-    dataName: 'neoplasmCountByStudy',
+    dataName: 'cancerTypeCountWidget',
   }
 ];

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -266,8 +266,8 @@ export const DASHBOARD_QUERY_NEW = gql`
       }   
     }
     
-    # Global Stats
-    globalStatsBar(
+    # Widget - Studies: Participant Count
+    participantCountWidget: globalStatsBar(
       study_short_name: $study_short_name
       study_type: $study_type
       study_design: $study_design
@@ -288,29 +288,46 @@ export const DASHBOARD_QUERY_NEW = gql`
       study_short_name
       number_of_participants
     }
-    studyDemographics(
+    # Widget - Studies: Cancer Type Count
+    cancerTypeCountWidget: globalStatsBar(
       study_short_name: $study_short_name
-      )
-    {
-    study_short_name
+      study_type: $study_type
+      study_design: $study_design
+      enrollment_beginning_year: $enrollment_beginning_year
+      enrollment_ending_year: $enrollment_ending_year
+      study_beginning_year: $study_beginning_year
+      study_ending_year: $study_ending_year
+      number_of_participants: $number_of_participants
+      cancer_diagnosis_primary_site_list: $cancer_diagnosis_primary_site_list
+      study_country: $study_country
+      biospecimen_collection: $biospecimen_collection
+      study_participant_maximum_age: $study_participant_maximum_age
+      study_participant_minimum_age: $study_participant_minimum_age
+      race: $race
+      ethnicity: $ethnicity
+      sex: $sex
+    ){
+      study_short_name
+      cancer_type_count
+    }
 
-    participant_races{
-      group
-      subjects
-        __typename
+    studyDemographics(study_short_name: $study_short_name) {
+      study_short_name
+
+      participant_races{
+        group
+        subjects
+      }
+      participant_sexes{
+        group
+        subjects
+      }
+      participant_count_by_age{
+        group
+        subjects
+      }
     }
-    participant_sexes{
-      group
-      subjects
-        __typename
-    }
-    participant_count_by_age{
-      group
-      subjects
-        __typename
-    }
-    __typename
-  }
+
     minMaxBoundQuery {
       number_of_participant_lower_bound
       number_of_participant_upper_bound

--- a/src/pages/dashTemplate/DashTemplateController.js
+++ b/src/pages/dashTemplate/DashTemplateController.js
@@ -40,15 +40,18 @@ const useDashData = (states) => {
 
         // Sort widget data
         sortWidgetDataByKey(result?.searchStudies?.studyCountByStudyDesign, 'group')
-        sortWidgetDataByKey(result?.globalStatsBar, 'study_short_name')
-        sortWidgetDataByKey(result?.searchStudies?.neoplasmCountByStudy, 'group')
+        sortWidgetDataByKey(result?.participantCountWidget, 'study_short_name')
+        sortWidgetDataByKey(result?.cancerTypeCountWidget, 'study_short_name')
         sortWidgetDataByKey(result?.studyDemographics?.number_of_participants, 'group')
 
         // Set the dashboard data with updated values
         setDashData(prevData => {
           const updatedData = {
             ...result.searchStudies, // All other Facet and widget
-            globalStatsBar: result.globalStatsBar, // Used to populate Studies widget data
+
+            participantCountWidget: result.participantCountWidget, // Used to populate "Studies: Participant Count" widget data
+            cancerTypeCountWidget: result.cancerTypeCountWidget, // Used to populate "Studies: Cancer Type Count" widget data
+
             studyDemographics: result.studyDemographics, // Used to populate barchart widget data
             ...numberOfParticipantsGlobalStats, // Global Stats - Participants 
 

--- a/src/pages/dashTemplate/widget/WidgetView.js
+++ b/src/pages/dashTemplate/widget/WidgetView.js
@@ -88,10 +88,12 @@ const WidgetView = ({
       functions: {
         mapData: (data) => {
           if (data.number_of_participants) return { name: data.study_short_name, value: data.number_of_participants }
+          if (data.cancer_type_count) return { name: data.study_short_name, value: data.cancer_type_count }
           return { name: data.group, value: data.subjects }
         },
         mapDatasetObject: (data) => {
           if (data.number_of_participants) return { name: data.study_short_name, value: data.number_of_participants }
+          if (data.cancer_type_count) return { name: data.study_short_name, value: data.cancer_type_count }
           return { name: data.group, value: data.subjects }
         },
         renderActiveShape: (props) => {


### PR DESCRIPTION
- Updated and rename using graphql alias for widget data sources from 'globalStatsBar' and 'neoplasmCountByStudy' to 'participantCountWidget' and 'cancerTypeCountWidget'. 
- Updated GraphQL queries, data mapping, and controller logic to use the new widget names and data structures.