### PR TITLE
POPSCI-371 Display placeholder charts when no data is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@bento-core/global-search": "1.0.1-ctdc.0",
     "@bento-core/paginated-table": "1.0.1-ctdc.7",
     "@bento-core/table": "1.0.1-ctdc.5",
-    "@bento-core/widgets": "1.0.1-ctdc.1",
+    "@bento-core/widgets": "^1.0.1-popsci.0",
     "@librpc/web": "^1.1.1",
     "@material-ui/core": "^4.12.4",
     "@material-ui/data-grid": "*",

--- a/src/pages/dashTemplate/widget/WidgetView.js
+++ b/src/pages/dashTemplate/widget/WidgetView.js
@@ -11,7 +11,6 @@ import { WidgetGenerator } from '@bento-core/widgets';
 import styles from './WidgetStyle';
 import { widgetConfig } from '../../../bento/dashTemplate';
 import colors from '../../../utils/colors';
-import { Typography } from '../../../components/Wrappers/Wrappers';
 import BarChartV2 from '../../../components/BarChartV2/bar-chart-v2';
 import { formatWidgetData } from './WidgetUtils';
 import sunburstStyle from './SunburstStyle'
@@ -55,7 +54,11 @@ const WidgetView = ({
           });
         }
       });
-    
+
+    if (Object.keys(counts).length === 0) {
+      counts[DEFAULT_VALUE] = 0;
+    }
+
     return Object.entries(counts).map(([group, count]) => ({
       group: capitalizeWordsExcept(group, ['or', 'and']),
       subjects: count
@@ -99,7 +102,7 @@ const WidgetView = ({
         renderActiveShape: (props) => {
           const {
             cx, cy, innerRadius, outerRadius, startAngle, endAngle,
-            fill, payload, value, textColor, fontSize, fontWeight, fontFamily,
+            fill, payload, value, textColor, fontSize, /* fontWeight, */ fontFamily,
             titleLocation, titleAlignment, sliceTitle, totalCount, showTotalCount, textOverflowLength,
           } = props;
     
@@ -231,10 +234,8 @@ const WidgetView = ({
       <Collapse in={collapse} className={classes.backgroundWidgets}>
         <Grid container>
           {widgetConfig.slice(0, 6).map((widget, index) => {
-            const dataset = displayWidgets[widget.dataName];
-            if (!dataset || dataset.length === 0) {
-              return <></>;
-            }
+            const dataset = displayWidgets[widget.dataName] || [];
+
             if (widget.type === 'sunburst' && (!dataset.children || !dataset.children.length)) {
               return <></>;
             }
@@ -265,40 +266,34 @@ const WidgetView = ({
         </Grid>
         <Grid container spacing={2} style={{ marginTop: 24 }}>
           {/* Participants: Age of Enrollment (left) */}
-          {processedAgeData && processedAgeData.length > 0 && (
-            <Grid item lg={4} md={6} sm={12} xs={12}>
-              <BarChartV2
-                chartData={processedAgeData}
-                chartTitle="Age at Enrollment"
-                titleStyle={barChartTitleStyle}
-                // chartwidth={320}
-                barWidth={30}
-              />
-            </Grid>
-          )}
+          <Grid item lg={4} md={6} sm={12} xs={12}>
+            <BarChartV2
+              chartData={processedAgeData}
+              chartTitle="Age at Enrollment"
+              titleStyle={barChartTitleStyle}
+              // chartwidth={320}
+              barWidth={30}
+            />
+          </Grid>
           {/* Participants: Races (middle) */}
-          {processedRaceData && processedRaceData.length > 0 && (
-            <Grid item lg={4} md={6} sm={12} xs={12}>
-              <BarChartV2
-                chartData={processedRaceData}
-                chartTitle="Race"
-                titleStyle={barChartTitleStyle}
-                // chartwidth={320}
-                barWidth={55}
-              />
-            </Grid>
-          )}
+          <Grid item lg={4} md={6} sm={12} xs={12}>
+            <BarChartV2
+              chartData={processedRaceData}
+              chartTitle="Race"
+              titleStyle={barChartTitleStyle}
+              // chartwidth={320}
+              barWidth={55}
+            />
+          </Grid>
           {/* Participants: Sex (right) */}
-          {processedSexData && processedSexData.length > 0 && (
-            <Grid item lg={4} md={6} sm={12} xs={12}>
-              <BarChartV2
-                chartData={processedSexData}
-                chartTitle="Sex"
-                titleStyle={barChartTitleStyle}
-                // chartwidth={320}
-              />
-            </Grid>
-          )}
+          <Grid item lg={4} md={6} sm={12} xs={12}>
+            <BarChartV2
+              chartData={processedSexData}
+              chartTitle="Sex"
+              titleStyle={barChartTitleStyle}
+              // chartwidth={320}
+            />
+          </Grid>
         </Grid>
       </Collapse>
     </>


### PR DESCRIPTION
### Overview

Updated visualization donut charts and pie charts to still show when there is no data.

> [!Warning]
> Bento PR (https://github.com/CBIIT/bento-frontend/pull/1139) should be merged first, will need to update package after publishing.

<img width="1345" height="731" alt="Screenshot 2025-08-29 at 2 08 11 PM" src="https://github.com/user-attachments/assets/7a0af83a-d927-440b-acd9-91101a5b32b5" />


### Change Details (Specifics)

- Removed guards preventing rendering of empty charts
- Updated pie chart counts to include fallback value so that charts still show
- Donut chart placeholder was applied in bento PR

### Related Ticket(s)

POPSCI-371