### PR TITLE
Fixed POPSCI-388, POPSCI-392, and POPSCI-377

### DIFF
--- a/src/bento/dashTemplate.js
+++ b/src/bento/dashTemplate.js
@@ -282,7 +282,7 @@ export const widgetConfig = [
     type: 'donut',
     title: 'Studies: Participant Count',
     sliceTitle: "Participants",
-    dataName: 'participantCountWidget',
+    dataName: 'participantCountWidgetAndStats',
   },
   {
     type: 'donut',

--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -267,7 +267,7 @@ export const DASHBOARD_QUERY_NEW = gql`
     }
     
     # Widget - Studies: Participant Count
-    participantCountWidget: globalStatsBar(
+    participantCountWidgetAndStats: globalStatsBar(
       study_short_name: $study_short_name
       study_type: $study_type
       study_design: $study_design

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -178,42 +178,6 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
   }
 `;
 
-export const GET_STUDY_DETAIL_DEMOGRAPHIC_DATA_QUERY = gql`
-query studyDemo($study_short_name: [String]) {
-  studyDemographics(study_short_name: $study_short_name) {
-    number_of_participants
-    
-    participant_age_range
-    participant_maximum_age # PARTICIPANT AGE RANGE (years)
-    participant_minimum_age # PARTICIPANT AGE RANGE (years)
-    participant_mean_age # MEAN PARTICIPANT AGE (years)
-    participant_median_age # MEDIAN PARTICIPANT AGE (years)
-    
-    #Participants: Age at Enrollment
-    participant_age_at_enrollment{
-      group
-      subjects
-    }
-
-    # PARTICIPANT_RACES
-    participant_races {
-      group
-      subjects
-    }
-    # PARTICIPANT ETHNICITIES
-    participant_ethnicities {
-      group
-      subjects
-    }
-    # PARTICIPANT SEXES
-    participant_sexes {
-      group
-      subjects
-    } 
-  }
-  
-}
-`;
 
 // --------------- Tabs Table configuration --------------
 export const studyPersonnelTableConfig = {
@@ -402,7 +366,7 @@ export const studyDataFileTableConfig = {
         openAccessIcon: directDownloadIcon,
         controlledAccessIcon: cloudOnlyAccessIcon,
       },
-      tooltipText: 'sort',
+      tooltipText: 'none',
       role: cellTypes.DISPLAY,
     },
 

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -366,7 +366,7 @@ export const studyDataFileTableConfig = {
         openAccessIcon: directDownloadIcon,
         controlledAccessIcon: cloudOnlyAccessIcon,
       },
-      tooltipText: 'none',
+      tooltipText: 'sort',
       role: cellTypes.DISPLAY,
     },
 

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -35,10 +35,24 @@ export const externalIcon = externalLinkIcon;
 export const previousPageIcon = previousIcon;
 
 export const GET_STUDY_DETAIL_DATA_QUERY = gql`
-  query study($study_short_name: [String]) {
+  query study(
+    $study_short_name: [String],
+    
+    $offset: Int,
+    $first: Int,
+    $order_by: String,
+    $sort_direction: String,
+  ) {
     
     ## Data for Cancer Types tab
-    primarySiteMorphology(study_short_name: $study_short_name) {
+    primarySiteMorphology(
+      study_short_name: $study_short_name
+      
+      first: $first
+      offset: $offset
+      order_by: $order_by
+      sort_direction: $sort_direction
+    ) {
       study_short_name,
       cancer_diagnosis_disease_morphology_collection {
         group
@@ -52,7 +66,15 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
     }
 
     # Study detail data for Demographics tab
-    studyDemographics(study_short_name: $study_short_name) {
+    studyDemographics(
+      study_short_name: $study_short_name
+      
+      # TODO: Needs to be added
+      # first: $first
+      # offset: $offset
+      # order_by: $order_by
+      # sort_direction: $sort_direction
+    ) {
       study_short_name
       number_of_participants
 
@@ -85,7 +107,15 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
       } 
     }
 
-    dataCollectionPage(study_short_name: $study_short_name) {
+    dataCollectionPage(
+      study_short_name: $study_short_name
+
+      # TODO: Needs to be added
+      # first: $first
+      # offset: $offset
+      # order_by: $order_by
+      # sort_direction: $sort_direction
+    ) {
       study_short_name
       data_collection {
         data_collection_category
@@ -93,7 +123,15 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
       }
     }
 
-    studyGeneral(study_short_name: $study_short_name) {
+    studyGeneral(
+      study_short_name: $study_short_name
+      
+      # TODO: Needs to be added
+      # first: $first
+      # offset: $offset
+      # order_by: $order_by
+      # sort_direction: $sort_direction
+    ) {
       study_short_name
 
       personnel {
@@ -122,7 +160,14 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
       }
     }
 
-    studyFiles( study_short_name: $study_short_name) {
+    studyFiles(
+      study_short_name: $study_short_name
+
+      first: $first
+      offset: $offset
+      order_by: $order_by
+      sort_direction: $sort_direction
+    ) {
       data_file_uuid
       data_file_name
       data_file_type
@@ -132,7 +177,15 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
       data_file_access_control
     }
 
-    tabStudy(study_short_name: $study_short_name) {
+    tabStudy(
+      study_short_name: $study_short_name
+      
+      # TODO: Needs to be added
+      # first: $first
+      # offset: $offset
+      # order_by: $order_by
+      # sort_direction: $sort_direction
+    ) {
       study_name
       study_short_name
       study_id
@@ -163,11 +216,21 @@ export const GET_STUDY_DETAIL_DATA_QUERY = gql`
     }
 
     # Stats Bar property
-    globalStatsBar(study_short_name: $study_short_name) {
+    globalStatsBar(
+      study_short_name: $study_short_name
+
+      # TODO: Needs to be added
+      # first: $first
+      # offset: $offset
+      # order_by: $order_by
+      # sort_direction: $sort_direction
+    ) {
       study_short_name
       number_of_participants
     }
-    searchStudies(study_short_name: $study_short_name) {
+    searchStudies(
+      study_short_name: $study_short_name
+    ) {
       dataVolume
       numberOfStudies
       numberOfDataCollectionCatagory

--- a/src/pages/dashTemplate/DashTemplateController.js
+++ b/src/pages/dashTemplate/DashTemplateController.js
@@ -30,7 +30,7 @@ const useDashData = (states) => {
     fetchDashData(client, activeFilters).then((result) => {
       if (result.searchStudies) {
         // Calculate global stats - number_of_participants
-        const numberOfParticipantsGlobalStats = calculateStatsTotals(result?.globalStatsBar || []);
+        const numberOfParticipantsGlobalStats = calculateStatsTotals(result?.participantCountWidgetAndStats || []);
 
         // Update slider data for different types
         const enrollmentPeriod = updateSliderData(result.searchStudies, result.minMaxBoundQuery, 'enrollmentPeriod', true)
@@ -40,7 +40,7 @@ const useDashData = (states) => {
 
         // Sort widget data
         sortWidgetDataByKey(result?.searchStudies?.studyCountByStudyDesign, 'group')
-        sortWidgetDataByKey(result?.participantCountWidget, 'study_short_name')
+        sortWidgetDataByKey(result?.participantCountWidgetAndStats, 'study_short_name')
         sortWidgetDataByKey(result?.cancerTypeCountWidget, 'study_short_name')
         sortWidgetDataByKey(result?.studyDemographics?.number_of_participants, 'group')
 
@@ -49,7 +49,7 @@ const useDashData = (states) => {
           const updatedData = {
             ...result.searchStudies, // All other Facet and widget
 
-            participantCountWidget: result.participantCountWidget, // Used to populate "Studies: Participant Count" widget data
+            participantCountWidgetAndStats: result.participantCountWidgetAndStats, // Used to populate "Studies: Participant Count" widget data
             cancerTypeCountWidget: result.cancerTypeCountWidget, // Used to populate "Studies: Cancer Type Count" widget data
 
             studyDemographics: result.studyDemographics, // Used to populate barchart widget data

--- a/src/pages/studyDetail/studyDetailController.js
+++ b/src/pages/studyDetail/studyDetailController.js
@@ -10,9 +10,8 @@ const StudyDetailController =  ({ match }) => {
   const { loading, error, data } = useQuery(GET_STUDY_DETAIL_DATA_QUERY, {
     variables: { 
       study_short_name: [match.params.id],
-      first: 0,
-      offset: 10,
-      order_by: 'study_short_name',
+      first: 1000,
+      offset: 0,
       sort_direction: 'ASC'
     },
   });

--- a/src/pages/studyDetail/studyDetailView.js
+++ b/src/pages/studyDetail/studyDetailView.js
@@ -57,7 +57,7 @@ const StudyDetailView = ({ classes, data, isLoading=false, isError=false, studyS
   const processedTabs = [
     { index: 0, label: 'Overview', content: <Overview data={studyGeneral || {}}  />},
     { index: 1, label: 'Cancer Types', content: <CancerTypes data={primarySiteMorphology || {}} /> },
-    { index: 2, label: 'Demographics', content: <Demographics data={studyDemographics || {}} studyShortName={studyShortName} /> },
+    { index: 2, label: 'Demographics', content: <Demographics data={studyDemographics || {}} /> },
     { index: 3, label: 'Data Collected' ,content: <DataCollection data={data?.dataCollectionPage[0].data_collection || {}} /> },
     { index: 4, label: 'Countries and States',content: <Country data={studyGeneral || {}} /> },
     { index: 5, label: 'Publications', content: <Publications data={studyGeneral || {}} /> },

--- a/src/pages/studyDetail/views/demographics/index.js
+++ b/src/pages/studyDetail/views/demographics/index.js
@@ -1,25 +1,15 @@
 import React from 'react';
 import { Grid, Typography, withStyles, useMediaQuery, CircularProgress } from '@material-ui/core';
-import { GET_STUDY_DETAIL_DEMOGRAPHIC_DATA_QUERY } from '../../../../bento/studyDetailData';
 import ThemeProvider from './themeConfig';
 import StatsSection from './components/StatsSection';
 import ChartSection from './components/ChartSection';
 import { capitalizeWordsExcept } from '../../common/utils';
-import { useMockQuery } from '../../../../utils/useMockQuery';
 import ErrorMessage from '../../../../components/ErrorMessage/ErrorMessage';
 
-const Demographics = ({ classes, data, studyShortName }) => {
-  // Mock Demographics Data
-  const { loading, error, mockData } = useMockQuery({
-    query: GET_STUDY_DETAIL_DEMOGRAPHIC_DATA_QUERY,
-    variables: { study_short_name: [studyShortName] },
-    selector: d => d.studyDemographics?.[0]
-  });
+const Demographics = ({ classes, data }) => {
 
   const isUnder800px = useMediaQuery('(max-width:800px)'); // Check if screen width is under 800px
 
-  if (loading) return <CircularProgress />;
-  if (error) return (<ErrorMessage message={`Error loading demographics tab. Error: ${error}`} />)
   if (!data || (typeof data === 'object' && Object.keys(data).length === 0)) {
     return (
       <div className={classes.page}>
@@ -58,13 +48,13 @@ const Demographics = ({ classes, data, studyShortName }) => {
       <div className={classes.page}>
         <Grid container spacing={3} className={classes.container}>
           <Grid item xs={12} sm={6} className={classes.section}>
-            <StatsSection data={processedData} mockData={mockData} />
+            <StatsSection data={processedData} />
           </Grid>
 
           {!isUnder800px && <div className={classes.divider} />}
 
           <Grid item xs={12} sm={6} className={classes.charts}>
-            <ChartSection data={processedData} mockData={mockData} />
+            <ChartSection data={processedData} />
           </Grid>
         </Grid>
       </div>


### PR DESCRIPTION
POPSCI-388:
- Updates the dashboard code to consistently use the new `participantCountWidgetAndStats` data field for the "Studies: Participant Count" widget, replacing the previous `participantCountWidget` field throughout the codebase. This change affects the GraphQL query, data processing, sorting, and widget configuration, ensuring that all components reference the updated field.

POPSCI-392:
- Fixed issue under Demographic tab by removing unused mock api

POPSCI-377:
- Fixed Mismatch between Study Files count in header and files displayed in table under Study Files tab
