### PR TITLE
POPSCI-391: Explore page -> Unnecessary horizontal scroll bar under “Participants: Age at Enrollment” chart

### DIFF
--- a/src/components/BarChartV2/bar-chart-v2.js
+++ b/src/components/BarChartV2/bar-chart-v2.js
@@ -60,7 +60,7 @@ const CustomTooltip = ({ active, payload, label }) => {
     padding: '10px',
     borderRadius: '5px',
     overflowWrap: 'break-word',
-    maxWidth: '170px',
+    maxWidth: '160px',
   };
 
   if (active && payload && payload.length) {

--- a/src/components/BarChartV2/bar-chart-v2.js
+++ b/src/components/BarChartV2/bar-chart-v2.js
@@ -122,6 +122,7 @@ const BarChartV2 = ({
           width={calculatedWidth}
           height={280}
           data={sortedData}
+          margin={{ top: 0, right: -5, left: 0, bottom: 0 }}
         >
           {/* <CartesianGrid strokeDasharray="3 3" /> */}
           <XAxis 

--- a/src/components/BarChartV2/bar-chart-v2.js
+++ b/src/components/BarChartV2/bar-chart-v2.js
@@ -60,7 +60,7 @@ const CustomTooltip = ({ active, payload, label }) => {
     padding: '10px',
     borderRadius: '5px',
     overflowWrap: 'break-word',
-    maxWidth: '160px',
+    maxWidth: '170px',
   };
 
   if (active && payload && payload.length) {


### PR DESCRIPTION
changed margins on the barchart to reduce whitespace on the right of the barchart, ensuring that the horizontal scroll bar only pops up when the chart is being cut off