### PR TITLE
POPSCI-389 [Bug]: Display full un-truncated name label for donut charts

### DIFF
--- a/src/pages/dashTemplate/DashTemplateStyle.js
+++ b/src/pages/dashTemplate/DashTemplateStyle.js
@@ -8,6 +8,11 @@ export default (theme) => ({
     margin: 'auto',
     padding: '0 32px',
   },
+  widgetsContainer: {
+    "& svg.recharts-surface, & .MuiPaper-root": {
+      overflow: "visible",
+    }
+  },
   sideBar: {
     minWidth: '285px',
     maxHeight: '1300px',

--- a/src/pages/dashTemplate/widget/WidgetView.js
+++ b/src/pages/dashTemplate/widget/WidgetView.js
@@ -107,6 +107,7 @@ const WidgetView = ({
           } = props;
     
           const isCapital = String(payload.name).toUpperCase() === String(payload.name);
+          // eslint-disable-next-line no-unused-vars
           const overflowLength = isCapital ? textOverflowLength : textOverflowLength + 10;
     
           const labelX = (titleAlignment === 'center') ? cx : (titleAlignment === 'left') ? 0 : cx * 2;
@@ -116,8 +117,8 @@ const WidgetView = ({
     
           return (
             <g>
-              <text x={labelX} y={labelY} dy={0} textAnchor={(titleAlignment === 'center') ? 'middle' : undefined} fill={'#0F253A'} fontSize={'16px'} fontWeight={'normal'} fontFamily={'Nunito'} cursor="text">
-                {String(payload.name).length > overflowLength ? `${String(payload.name).substring(0, overflowLength)}...` : payload.name}
+              <text x={labelX} y={labelY} dy={0} textAnchor={(titleAlignment === 'center') ? 'middle' : undefined} fill={'#0F253A'} fontSize={'16px'} fontWeight={'normal'} fontFamily={'Nunito'} cursor="text" overflow="visible">
+                {String(payload.name)}
                 <title>{payload.name}</title>
               </text>
               <text x={cx} y={cy} dy={0} textAnchor="middle" fill={textColor} fontSize={fontSize || '12px'} fontWeight="bold" fontFamily={fontFamily || 'Nunito'}>


### PR DESCRIPTION
### Overview

The labels in the donut charts were being cut off at the edges and was being truncated after a certain amount of characters. They want the label to always being shown fully and never cut off.

### Change Details (Specifics)

- Removed label truncation
- Allowed overflow of the donut chart label. Shouldn't be an issue, unless the screen is very small and/or the titles are extremely long

<details>
<summary>Before</summary>
<img width="275" height="292" alt="Screenshot 2025-09-10 at 1 26 55 PM" src="https://github.com/user-attachments/assets/c5d84e0f-2ca7-48b3-bfd8-17557337d2f6" />
</details>

<details>
<summary>After</summary>
<img width="352" height="277" alt="Screenshot 2025-09-10 at 1 27 00 PM" src="https://github.com/user-attachments/assets/64d26595-de1a-4703-9917-5e0d44163f2c" />
</details>

### Related Ticket(s)

[POPSCI-389](https://tracker.nci.nih.gov/browse/POPSCI-389)
