### PR TITLE
POPSCI-159 [Bug]: Facet Filter tooltip wrapping

### DIFF
--- a/src/pages/dashTemplate/sideBar/BentoFacetFilterStyle.js
+++ b/src/pages/dashTemplate/sideBar/BentoFacetFilterStyle.js
@@ -143,8 +143,10 @@ export default () => ({
     border: '1px solid #818181',
     boxShadow: '0px 4px 4px 0px #00000040',
 
-    maxWidth: '270px',
-    height: '32px',
+    whiteSpace: 'nowrap',
+    width: '270px',
+    maxWidth: 'none',
+    minHeight: '32px',
     padding: '6px 10px'
   },
   customArrow: {},


### PR DESCRIPTION
### Overview

Fixed the Facet Filter tooltip text wrapping into a new line and overflowing. (Ex. "Filter by Studies" tooltip)

### Change Details (Specifics)

N/A

### Related Ticket(s)

[POPSCI-159](https://tracker.nci.nih.gov/browse/POPSCI-159)