### PR TITLE
POPSCI-403 [Bug]: Update File Names for downloaded CSV's

### DIFF
--- a/src/bento/dashboardTabData.js
+++ b/src/bento/dashboardTabData.js
@@ -874,7 +874,7 @@ export const tabContainers = [
       },
       download: {
         downloadCsv: "Download Table Contents As CSV",
-        downloadFileName: "popsci_download",
+        downloadFileName: "PSDC_Studies",
       },
     },
     columns: [

--- a/src/bento/fileCentricCartWorkflowData.js
+++ b/src/bento/fileCentricCartWorkflowData.js
@@ -180,7 +180,7 @@ export const createDownloadTableFunction = (client, filterItems) => () => {
         downloadJson(
           result.data[table.objectKey],
           "",
-          table?.extendedViewConfig?.download?.downloadFileName || "PSDC_My_Files_download",
+          table?.extendedViewConfig?.download?.downloadFileName || "PSDC_My_Files",
           {
             keysToInclude: ['data_file_name', 'data_file_type', 'data_file_description', 'data_file_format', 'data_volume', 'data_file_access_control', 'data_file_access_control'],
             header: ['File Name', 'File Type', 'Description', 'Format', 'Size', 'Access Control', 'File Delivery'],
@@ -210,7 +210,7 @@ export const table = {
     manageViewColumns: { title: "View Columns" },
     download: {
     // tableDownloadCSV: customMyFilesTabDownloadCSV,
-      downloadFileName: "PSDC_My_Files_download",
+      downloadFileName: "PSDC_My_Files",
       // This function should be replaced in React component with createDownloadTableFunction(client)
       downloadTable: null
     },

--- a/src/bento/studyDetailData.js
+++ b/src/bento/studyDetailData.js
@@ -349,7 +349,7 @@ export const studyDataFileTableConfig = {
   extendedViewConfig: {
     pagination: true, // Top pagination: true || false
     manageViewColumns: { title: "View Columns" },
-    download: { downloadCsv: "Download Table Contents As CSV", downloadFileName: "Study_Files_download",},
+    download: { downloadCsv: "Download Table Contents As CSV", downloadFileName: "PSDC_Study_Files",},
   },
   columns: [
     {


### PR DESCRIPTION
### Overview

Updated downloaded CSV file names to be more consistent and start with "PSDC_"

### Change Details (Specifics)

Updated download file names in the following locations:
 - Explore studies table export
 - Study Files table export
 - Cart table export

### Related Ticket(s)

[POPSCI-403](https://tracker.nci.nih.gov/browse/POPSCI-403)