### PR TITLE
POPSCI-380: Add PortalTooltip for unclipped chart tooltips

### DIFF
--- a/src/components/BarChartV2/PortalTooltip.js
+++ b/src/components/BarChartV2/PortalTooltip.js
@@ -76,8 +76,6 @@ export default function PortalTooltip({
     Math.min(window.innerHeight - padding - estHeight,         // not below viewport
              mouse.y - 24)                                      // lift above cursor
   );
-  console.log("|||: Tooltip: ", { left, top, mouse, payload, value });
-
   // ---- Render via React Portal ----
   // Instead of rendering inside the <svg>, this creates a floating <div>
   // directly under <body>. That means it won't get clipped by parent

--- a/src/components/BarChartV2/PortalTooltip.js
+++ b/src/components/BarChartV2/PortalTooltip.js
@@ -90,7 +90,7 @@ export default function PortalTooltip({
         maxWidth,           // match tooltip width
         background: '#fff',          // white background
         border: '1px solid #ccc',    // subtle border
-        borderRadius: 5,               // rounded corners
+        borderRadius: '5px',               // rounded corners
         padding: 10,                   // inner spacing
         overflowWrap: 'break-word',    // wrap long group names
         pointerEvents: 'none',         // don't block mouse interactions

--- a/src/components/BarChartV2/PortalTooltip.js
+++ b/src/components/BarChartV2/PortalTooltip.js
@@ -87,7 +87,7 @@ export default function PortalTooltip({
         left,                          // computed horizontal position
         top,                           // computed vertical position
         zIndex: 9999,                  // sit above everything else
-        maxWidth: maxWidth,           // match tooltip width
+        maxWidth,           // match tooltip width
         background: '#fff',          // white background
         border: '1px solid #ccc',    // subtle border
         borderRadius: 5,               // rounded corners

--- a/src/components/BarChartV2/PortalTooltip.js
+++ b/src/components/BarChartV2/PortalTooltip.js
@@ -19,6 +19,10 @@
  * - Smart enough to flip to the left side if you’re near the right edge of the viewport.
  * - Clamps vertically so it won’t overflow above/below the window.
  * - Still shows the same content (Group + Participants) as CustomTooltip.
+ *
+ * Implementation note:
+ * - The pointermove listener is now bound to the chart’s scrollable wrapper (chartAreaRef) if provided,
+ *   otherwise it falls back to window. This scopes tracking to the interactive area.
  */
 
 import React, { useEffect, useState } from 'react';
@@ -28,7 +32,7 @@ export default function PortalTooltip({
   active,
   payload,
   label,
-
+  eventTarget,
   // optional tuning props to control tooltip layout
   maxWidth = 160,   // match tooltip maxWidth
   offset = 12,      // distance (px) from the cursor
@@ -38,16 +42,26 @@ export default function PortalTooltip({
   // Track the current mouse position so we can place tooltip relative to it
   const [mouse, setMouse] = useState({ x: 0, y: 0 });
 
+  // Attach listener only when tooltip is active; bind to chartAreaRef if provided
   useEffect(() => {
-    // Update mouse position whenever the cursor moves
-    const onMove = (e) => setMouse({ x: e.clientX, y: e.clientY });
+    if (!active) return;
+    if (typeof window === 'undefined') return;
 
-    // Attach listener on mount
-    window.addEventListener('mousemove', onMove, { passive: true });
+    const targetEl = eventTarget?.current || window;
 
-    // Cleanup listener on unmount
-    return () => window.removeEventListener('mousemove', onMove);
-  }, []);
+    // Use pointermove to cover mouse/pen/touch; falls back to clientX/clientY
+    const onMove = (e) =>
+      setMouse({
+        x: (typeof e.clientX === 'number') ? e.clientX : 0,
+        y: (typeof e.clientY === 'number') ? e.clientY : 0,
+      });
+
+    targetEl.addEventListener('pointermove', onMove, { passive: true });
+
+    return () => {
+      targetEl.removeEventListener('pointermove', onMove);
+    };
+  }, [active, eventTarget]);
 
   // Recharts passes these props: only show tooltip when hovering a bar
   if (!active || !payload?.length) return null;
@@ -56,7 +70,6 @@ export default function PortalTooltip({
   const value = payload[0]?.value != null ? payload[0].value.toLocaleString() : '';
 
   // ---- Horizontal positioning logic ----
-
   // Space available to the right of the cursor
   const roomOnRight = window.innerWidth - mouse.x - padding;
 
@@ -69,13 +82,13 @@ export default function PortalTooltip({
     : Math.max(padding, mouse.x - maxWidth - offset);                    // place on left
 
   // ---- Vertical positioning logic ----
-
   // Calculate `top` position: slightly above cursor, but clamped inside viewport
   const top = Math.max(
-    padding,                                                    // not above viewport
-    Math.min(window.innerHeight - padding - estHeight,         // not below viewport
-             mouse.y - 24)                                      // lift above cursor
+    padding,                                                     // not above viewport
+    Math.min(window.innerHeight - padding - estHeight,           // not below viewport
+             mouse.y - 24)                                       // lift above cursor
   );
+
   // ---- Render via React Portal ----
   // Instead of rendering inside the <svg>, this creates a floating <div>
   // directly under <body>. That means it won't get clipped by parent
@@ -87,10 +100,10 @@ export default function PortalTooltip({
         left,                          // computed horizontal position
         top,                           // computed vertical position
         zIndex: 9999,                  // sit above everything else
-        maxWidth,           // match tooltip width
-        background: '#fff',          // white background
-        border: '1px solid #ccc',    // subtle border
-        borderRadius: '5px',               // rounded corners
+        maxWidth,                      // match tooltip width
+        background: '#fff',            // white background
+        border: '1px solid #ccc',      // subtle border
+        borderRadius: '5px',           // rounded corners
         padding: 10,                   // inner spacing
         overflowWrap: 'break-word',    // wrap long group names
         pointerEvents: 'none',         // don't block mouse interactions

--- a/src/components/BarChartV2/PortalTooltip.js
+++ b/src/components/BarChartV2/PortalTooltip.js
@@ -44,8 +44,7 @@ export default function PortalTooltip({
 
   // Attach listener only when tooltip is active; bind to chartAreaRef if provided
   useEffect(() => {
-    if (!active) return;
-    if (typeof window === 'undefined') return;
+    if (typeof window === 'undefined' || !active) return;
 
     const targetEl = eventTarget?.current || window;
 

--- a/src/components/BarChartV2/PortalTooltip.js
+++ b/src/components/BarChartV2/PortalTooltip.js
@@ -1,0 +1,112 @@
+/**
+ * Assumptions & Purpose:
+ *
+ * By default, Recharts tooltips render inside the <svg> element of the chart.
+ * - If the chart is narrower than the total number of bars, a scrolling container with `overflow: auto` is created.
+ * - Tooltips rendered inside the chart’s <svg> can get clipped (cut off) when they should appear outside the visible area.
+ *
+ * Solution:
+ * - Render the tooltip outside of the chart’s DOM hierarchy (e.g., in <body>), where it’s free from clipping.
+ * - This is achieved using React Portals.
+ *
+ * CustomTooltip (old behavior):
+ * - Rendered inside the chart.
+ * - Got clipped when the chart was scrollable.
+ *
+ * PortalTooltip (new behavior):
+ * - Renders outside the chart (in <body>) using a portal.
+ * - Dynamically positions itself relative to the cursor position.
+ * - Smart enough to flip to the left side if you’re near the right edge of the viewport.
+ * - Clamps vertically so it won’t overflow above/below the window.
+ * - Still shows the same content (Group + Participants) as CustomTooltip.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export default function PortalTooltip({
+  active,
+  payload,
+  label,
+
+  // optional tuning props to control tooltip layout
+  maxWidth = 160,   // match tooltip maxWidth
+  offset = 12,      // distance (px) from the cursor
+  padding = 8,      // padding from viewport edges
+  estHeight = 72,   // estimated tooltip height, used for vertical clamping
+}) {
+  // Track the current mouse position so we can place tooltip relative to it
+  const [mouse, setMouse] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    // Update mouse position whenever the cursor moves
+    const onMove = (e) => setMouse({ x: e.clientX, y: e.clientY });
+
+    // Attach listener on mount
+    window.addEventListener('mousemove', onMove, { passive: true });
+
+    // Cleanup listener on unmount
+    return () => window.removeEventListener('mousemove', onMove);
+  }, []);
+
+  // Recharts passes these props: only show tooltip when hovering a bar
+  if (!active || !payload?.length) return null;
+
+  // Extract value (formatted with commas) for display
+  const value = payload[0]?.value != null ? payload[0].value.toLocaleString() : '';
+
+  // ---- Horizontal positioning logic ----
+
+  // Space available to the right of the cursor
+  const roomOnRight = window.innerWidth - mouse.x - padding;
+
+  // Decide if we should place tooltip on the right or left of cursor
+  const placeRight = roomOnRight > maxWidth + offset;
+
+  // Calculate `left` position: clamp within viewport so it never overflows
+  const left = placeRight
+    ? Math.min(window.innerWidth - padding - maxWidth, mouse.x + offset) // place on right
+    : Math.max(padding, mouse.x - maxWidth - offset);                    // place on left
+
+  // ---- Vertical positioning logic ----
+
+  // Calculate `top` position: slightly above cursor, but clamped inside viewport
+  const top = Math.max(
+    padding,                                                    // not above viewport
+    Math.min(window.innerHeight - padding - estHeight,         // not below viewport
+             mouse.y - 24)                                      // lift above cursor
+  );
+  console.log("|||: Tooltip: ", { left, top, mouse, payload, value });
+
+  // ---- Render via React Portal ----
+  // Instead of rendering inside the <svg>, this creates a floating <div>
+  // directly under <body>. That means it won't get clipped by parent
+  // containers (e.g., scrolling wrappers or overflow: hidden).
+  return createPortal(
+    <div
+      style={{
+        position: 'fixed',             // lock position relative to viewport
+        left,                          // computed horizontal position
+        top,                           // computed vertical position
+        zIndex: 9999,                  // sit above everything else
+        maxWidth: maxWidth,           // match tooltip width
+        background: '#fff',          // white background
+        border: '1px solid #ccc',    // subtle border
+        borderRadius: 5,               // rounded corners
+        padding: 10,                   // inner spacing
+        overflowWrap: 'break-word',    // wrap long group names
+        pointerEvents: 'none',         // don't block mouse interactions
+        boxShadow: '0 6px 24px rgba(0,0,0,.18)', // subtle shadow
+        fontFamily: 'Open Sans',
+        fontSize: 12,
+        lineHeight: 1.35,
+      }}
+      role="tooltip"
+    >
+      {/* Tooltip content */}
+      <p style={{ margin: 0, fontWeight: 'bold' }}>{`Group: ${label}`}</p>
+      <p style={{ margin: 0 }}>{`Participants: ${value}`}</p>
+    </div>,
+    document.body // <--- injected here instead of inside the chart <svg>
+  );
+}

--- a/src/components/BarChartV2/bar-chart-v2.js
+++ b/src/components/BarChartV2/bar-chart-v2.js
@@ -10,6 +10,7 @@ import {
   Text,
   Tooltip
 } from 'recharts';
+import PortalTooltip from './PortalTooltip';
 
 const styles = theme => ({
   container: {
@@ -102,6 +103,7 @@ const BarChartV2 = ({
   barWidth = 50,
   titleStyle = {},
   fromChartSection = false,
+  usePortalTooltip = true,
 }) => {
   const containerRef = useRef(null);
   const [containerWidth, setContainerWidth] = useState(fromChartSection ? 320 : 0);
@@ -181,7 +183,16 @@ const BarChartV2 = ({
             height={60}
             interval={0}
           />
-          <Tooltip content={<CustomTooltip />} />
+          <Tooltip
+            content={
+              usePortalTooltip
+                ? <PortalTooltip maxWidth={160} offset={12} padding={8} estHeight={72} />
+                : <CustomTooltip />
+            }
+            // Recharts always renders an internal wrapper <div> for the tooltip.
+            // Hide that wrapper ONLY when using the portal variant to avoid double tooltips.
+            wrapperStyle={usePortalTooltip ? { visibility: 'hidden' } : undefined}
+          />
           <Bar dataKey="subjects" maxBarSize={60}>
             {sortedData.map((_entry, index) => (
               <Cell

--- a/src/components/BarChartV2/bar-chart-v2.js
+++ b/src/components/BarChartV2/bar-chart-v2.js
@@ -106,6 +106,7 @@ const BarChartV2 = ({
   usePortalTooltip = true,
 }) => {
   const containerRef = useRef(null);
+  const chartAreaRef = useRef(null); // listens only over the scrollable chart area
   const [containerWidth, setContainerWidth] = useState(fromChartSection ? 320 : 0);
 
   useEffect(() => {
@@ -170,6 +171,7 @@ const BarChartV2 = ({
           width: '100%',
           justifyContent: hasOverflow ? 'flex-start' : 'center',
         }}
+        ref={chartAreaRef} // attaching ref to the interactive scroll wrapper
       >
         <BarChart
           width={calculatedWidth}
@@ -186,7 +188,7 @@ const BarChartV2 = ({
           <Tooltip
             content={
               usePortalTooltip
-                ? <PortalTooltip maxWidth={160} offset={12} padding={8} estHeight={72} />
+                ? <PortalTooltip eventTarget={chartAreaRef} maxWidth={160} offset={12} padding={8} estHeight={72} />
                 : <CustomTooltip />
             }
             // Recharts always renders an internal wrapper <div> for the tooltip.


### PR DESCRIPTION
This pull request introduces a major improvement to the tooltip behavior in the `BarChartV2` component, addressing issues where tooltips were previously clipped when the chart was scrollable. The new solution leverages React Portals to render tooltips outside the chart's DOM hierarchy, ensuring they remain visible and properly positioned regardless of chart overflow. The implementation is opt-in via a new `usePortalTooltip` prop.